### PR TITLE
PowerShell script for starting both backend and frontend.

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -1,0 +1,7 @@
+Write-Host "🚀 Starting Backend..."
+Start-Process powershell -ArgumentList "-NoExit", "-Command",
+    ". .venv/Scripts/Activate.ps1; cd backend/models; uvicorn main:app --reload"
+
+Write-Host "🚀 Starting Frontend..."
+Start-Process powershell -ArgumentList "-NoExit", "-Command",
+    "cd rag-client; npm run dev"


### PR DESCRIPTION
docs: add instructions for running backend & frontend with start.ps1 script

- Added PowerShell script (start.ps1) to start both backend (FastAPI) and frontend (React) together.
- To enable script execution, run once in PowerShell as Administrator:
  Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
- After that, run the project with:
  .\start.ps1
- The script will open two PowerShell windows:
  1. Backend (FastAPI with uvicorn)
  2. Frontend (React with npm run dev)
